### PR TITLE
example system: ease entry to documentation

### DIFF
--- a/Documentation/xen-demo-zcu102/Readme.md
+++ b/Documentation/xen-demo-zcu102/Readme.md
@@ -1,4 +1,27 @@
 # Table of Contents
+
+## Introduction
+
+The example system setup should illustrate the interaction of different system components
+represented by Zephyr as RTOS running on the µProcessor on top of Xen as Hypervisor, and with a Linux flavour (yocto, Debian) as an additional domain/VM next to Zepyhr. 
+
+In the example system the hardware is represented by a Xilinx ZCU102. It can also be a 
+Qemu image. The below image illustrates the essential blocks of the example system.
+
+![System Overview](images/system-overview.drawio.svg)
+
+An overview of the central elements involved in the build, as software elements, 
+hardware and peripherals (local tools) can be depicted from the system component overview
+below:
+
+![System Components Overview](images/system-components.drawio.svg)
+
+It is intended to enhance the demo to further configurations and to replace central elements 
+by adding alternative implementation for the hardware and system elements.
+
+Demo cases should be enhanced to represent real world use cases and help as an example
+to create own use case on top.
+
 ## Setup
 
 [Overview to all parts of XEN demo](overview2parts.md)

--- a/Documentation/xen-demo-zcu102/images/system-components.drawio.svg
+++ b/Documentation/xen-demo-zcu102/images/system-components.drawio.svg
@@ -1,0 +1,433 @@
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="641px" height="491px" viewBox="-0.5 -0.5 641 491" content="&lt;mxfile&gt;&lt;diagram id=&quot;Nm0YGBIGDFNbZBoN8MKj&quot; name=&quot;Page-1&quot;&gt;7Vxdc9o4FP01zHQf0rEt2yGPhCSbh+5Opp5O076pWAFNjMUIEWB//UpYso2lNHwIOXFJZoh1sWxxzr3HV7oiPTCcrv6mcDb5h6Qo6wVeuuqBm14Q+B6I+R9hWReWGIDCMKY4lSdVhgT/h1RPaV3gFM23TmSEZAzPto0jkudoxLZskFKy3D7tiWTbd53BMdIMyQhmuvU7TtmksPYjr7LfIzyeqDv7nnxnCtXJ0jCfwJQsayZw2wNDSggrjqarIcoEeAqXot/dK++WA6MoZ7t0iCTwLzBbyA8nB8bW6tMuJ5ihZAZHor3kjPbA9YRNM97y+eGcUfKMhiQjdHM+GG5++DtPJGc1u7f5EXacZcqekxyVF1FgistSsshTJIYpuowzOJ/L4xIz0ZDDR5Sh1asY+CWy3CURmSJG1/wU2SGUXEhnDPuyvayojYG0TWq0Krqh9KZxeeUKcH4gMTfjH8Rv418hIXDZlw2B+b5spHA+KW9oAeEAbEN8pSPshwaEQWwBYiUaNYivF5hHPAeZLOiIC4ldxOP4Ori72w9xCyD7QcOPTSgHJpRtgOxrIH8hXDClMtuGWLh0AaVTiKOmVDiFONAgTr4Xw2f28d1fNGzoRNwmvvqj8B7SdMlHbxndvid+naMbem2iG+oCgcYo528PNHj5Z2QacBIImOFxzpsZemJmqGrQC7wwl6GB7DTFaSpuYqRsO+N4lRtuT+RQfQusRG+TEp+Kk0jj5BFnOF9x2w8yYoT/5b/B5yJJpvz18fbfbjwtw7czElMo2EhIIl+DEKV8fiGbuhejFWaPteMfwkU/R7J1s5Ieu2msVSPno3qsN2q9RLPqtmmpfq+xwCN1IGZO1QC55Q6LD1nLw8Xn+D0hKumSJpn+MkjHSJ5WZMA6cRRlkOGX7esf5f567n2dPAhD6fS9IM6Eyvzivh+PxdHP4Tdu9z3bafr7CAP/csc4sDH3iXQM/9g4uDTEAXAVB5daHAxm4sHJs0pPTpU66Otl24Wvh5dnX1dn9Q2+Hrny9b7m61+Hg6/ckqIpybmrQrZJdD7xS8OLFbuYUZJepOgFZRd0BOlfnYwF4DvMf/wr/bkrVAbnY5Fhopy/3q+5Ar3g+YaLJeZjCrwHzsgXnC9WtbS0i1y4zEXDqwN1ydtDlw7Vl1LP/P307DBdUhDXdck/Vpdk1weC+Z2rpbrGOkdZH1CXKMYgezXYLIex2wKzYfWTEJYRmCJqOX7aWjVqJrHejgEU2gig82SuDCBViqsFEHA1mVNJ2kmF7FBBap+Ho4Vs54KWXggonujJes7QtKOKE7tUnPO0ufT0oEXFUTev12PwdMZJKFLVrEhVu+jvZVbhxN+BA38/OkXdM04O9HdwAn83p6jNYlG5Qn6CFFUvvFXrT59u0C8Mc9vT7vcSSIa9JqcLpPD84FCBFLb44Aj7B/LQwTm3gYdiie7kc25tWdeioOm17p9oNll3dL4Ndl1ItyJi0VnEVPBEbYpY7EDEPsh828BDscbtYhai7+G4QVOxc2OO2GLWlY1hzY13Lpf4Ar0+qvY25ogtCX3WtwnIksXN/fDBOgOtbH3UGXBIgF60SxDFGwZGJJ+TzPYOvbb2lzb3PzoEGbznStCBwnysCJszSdBgqVmHs5hI6pXSbwkHw7tlE0S5+OjCA1M4Y9YrO+9lx6rLeHCRaH6MZSe113Qr0Tx2d5I5tpoKqFFpL7iAi2n4x8hgTQQXWY+DDFbd3JBeVTLXRTVzWqcGh87XOihnpjr1h5czdeWznBkJrn279sRyphfAE/7iDSFNu6ljTquB4LyRtnTz4AQ6tjMPgebmxdQkYXj03FFHd1mtA4dW6zqo54ay99Fz+515+N3XQl19O6ilAGimL6fc58Sb1b+9KPKf6p+HgNv/AQ==&lt;/diagram&gt;&lt;/mxfile&gt;">
+    <defs/>
+    <g>
+        <rect x="0" y="440" width="630" height="50" fill="none" stroke="#cccccc" pointer-events="all"/>
+        <rect x="190" y="50" width="140" height="360" rx="21" ry="21" fill="none" stroke="#0000cc" stroke-dasharray="3 3" pointer-events="all"/>
+        <rect x="80" y="450" width="120" height="30" rx="4.5" ry="4.5" fill="none" stroke="#66b2ff" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 465px; margin-left: 81px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Build sources
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="140" y="469" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Build sources
+                </text>
+            </switch>
+        </g>
+        <rect x="500" y="450" width="120" height="30" rx="4.5" ry="4.5" fill="none" stroke="#00cc00" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 465px; margin-left: 501px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Local tools
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="560" y="469" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Local tools
+                </text>
+            </switch>
+        </g>
+        <rect x="220" y="450" width="120" height="30" rx="4.5" ry="4.5" fill="none" stroke="#0000cc" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 465px; margin-left: 221px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                SW parts
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="280" y="469" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    SW parts
+                </text>
+            </switch>
+        </g>
+        <rect x="360" y="450" width="120" height="30" rx="4.5" ry="4.5" fill="none" stroke="#808080" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 465px; margin-left: 361px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Hardware
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="420" y="469" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Hardware
+                </text>
+            </switch>
+        </g>
+        <rect x="10" y="450" width="60" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 58px; height: 1px; padding-top: 465px; margin-left: 12px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; overflow-wrap: normal;">
+                                Legend:
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="12" y="469" fill="#000000" font-family="Helvetica" font-size="12px" font-weight="bold">
+                    Legend:
+                </text>
+            </switch>
+        </g>
+        <rect x="0" y="50" width="120" height="60" rx="9" ry="9" fill="none" stroke="#66b2ff" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 80px; margin-left: 1px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Xilinx Yocto 2022.2 for XEN
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="60" y="84" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Xilinx Yocto 2022.2...
+                </text>
+            </switch>
+        </g>
+        <path d="M 120 155 L 200 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="0" y="130" width="120" height="50" rx="7.5" ry="7.5" fill="none" stroke="#66b2ff" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 155px; margin-left: 1px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                BSP v2022.2
+                                <br/>
+                                ZCU 102
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="60" y="159" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    BSP v2022.2...
+                </text>
+            </switch>
+        </g>
+        <path d="M 120 225 L 200 260" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="0" y="200" width="120" height="50" rx="7.5" ry="7.5" fill="none" stroke="#66b2ff" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 225px; margin-left: 1px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Apertis Build
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="60" y="229" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Apertis Build
+                </text>
+            </switch>
+        </g>
+        <path d="M 120 300 L 200 380" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="0" y="270" width="120" height="60" rx="9" ry="9" fill="none" stroke="#66b2ff" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 300px; margin-left: 1px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                RCAR demonstrator (meta-xt-prod-devel-rcar)
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="60" y="304" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    RCAR demonstrator (m...
+                </text>
+            </switch>
+        </g>
+        <rect x="0" y="350" width="120" height="60" rx="9" ry="9" fill="none" stroke="#66b2ff" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 380px; margin-left: 1px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Building Xen Hypervisor with PetaLinux 2022.2
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="60" y="384" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Building Xen Hypervi...
+                </text>
+            </switch>
+        </g>
+        <path d="M 200 80 L 120 80" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="200" y="60" width="120" height="40" rx="6" ry="6" fill="none" stroke="#0000cc" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 80px; margin-left: 201px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Bootloader
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="260" y="84" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Bootloader
+                </text>
+            </switch>
+        </g>
+        <path d="M 320 140 L 360 260" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 200 140 L 120 80" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="200" y="120" width="120" height="40" rx="6" ry="6" fill="none" stroke="#0000cc" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 140px; margin-left: 201px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Xen System
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="260" y="144" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Xen System
+                </text>
+            </switch>
+        </g>
+        <path d="M 320 200 L 360 260" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="200" y="180" width="120" height="40" rx="6" ry="6" fill="none" stroke="#0000cc" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 200px; margin-left: 201px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Simple Petalinux
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="260" y="204" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Simple Petalinux
+                </text>
+            </switch>
+        </g>
+        <path d="M 320 260 L 360 260" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="200" y="240" width="120" height="40" rx="6" ry="6" fill="none" stroke="#0000cc" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 260px; margin-left: 201px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Apertis (Debian)
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="260" y="264" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Apertis (Debian)
+                </text>
+            </switch>
+        </g>
+        <path d="M 320 320 L 360 260" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 200 320 L 120 300" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="200" y="300" width="120" height="40" rx="6" ry="6" fill="none" stroke="#0000cc" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 320px; margin-left: 201px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Zephyr
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="260" y="324" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Zephyr
+                </text>
+            </switch>
+        </g>
+        <path d="M 320 380 L 360 260" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 200 380 L 120 380" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="200" y="360" width="120" height="40" rx="6" ry="6" fill="none" stroke="#0000cc" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 380px; margin-left: 201px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Demo setups
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="260" y="384" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Demo setups
+                </text>
+            </switch>
+        </g>
+        <rect x="200" y="0" width="120" height="40" rx="6" ry="6" fill="none" stroke="#00cc00" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 20px; margin-left: 201px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Local network
+                                <br/>
+                                with DHCP
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="260" y="24" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Local network...
+                </text>
+            </switch>
+        </g>
+        <rect x="520" y="0" width="120" height="40" rx="6" ry="6" fill="none" stroke="#00cc00" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 20px; margin-left: 521px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Serial console
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="580" y="24" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Serial console
+                </text>
+            </switch>
+        </g>
+        <path d="M 360 20 L 320 20" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="360" y="0" width="120" height="40" rx="6" ry="6" fill="none" stroke="#808080" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 20px; margin-left: 361px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                USB Ethernet
+                                <br/>
+                                adapter
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="420" y="24" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    USB Ethernet...
+                </text>
+            </switch>
+        </g>
+        <path d="M 480 80 L 520 140" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 360 80 L 320 20" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="360" y="60" width="120" height="40" rx="6" ry="6" fill="none" stroke="#808080" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 80px; margin-left: 361px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Local Ethernet
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="420" y="84" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Local Ethernet
+                </text>
+            </switch>
+        </g>
+        <path d="M 480 200 L 520 140" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 360 200 L 320 80" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="360" y="180" width="120" height="40" rx="6" ry="6" fill="none" stroke="#808080" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 200px; margin-left: 361px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                SD Card
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="420" y="204" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    SD Card
+                </text>
+            </switch>
+        </g>
+        <path d="M 480 260 L 520 140" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="360" y="240" width="120" height="40" rx="6" ry="6" fill="none" stroke="#808080" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 260px; margin-left: 361px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                USB Stick
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="420" y="264" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    USB Stick
+                </text>
+            </switch>
+        </g>
+        <path d="M 520 140 L 480 20" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="520" y="120" width="120" height="40" rx="6" ry="6" fill="none" stroke="#808080" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 140px; margin-left: 521px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Hardware
+                                <br/>
+                                ZCU 102
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="580" y="144" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Hardware...
+                </text>
+            </switch>
+        </g>
+    </g>
+    <switch>
+        <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
+        <a transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank">
+            <text text-anchor="middle" font-size="10px" x="50%" y="100%">
+                Text is not SVG - cannot display
+            </text>
+        </a>
+    </switch>
+</svg>

--- a/Documentation/xen-demo-zcu102/images/system-overview.drawio.svg
+++ b/Documentation/xen-demo-zcu102/images/system-overview.drawio.svg
@@ -1,0 +1,117 @@
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="301px" height="241px" viewBox="-0.5 -0.5 301 241" content="&lt;mxfile&gt;&lt;diagram id=&quot;e-AJZFzIj5AeoN5nGere&quot; name=&quot;Page-1&quot;&gt;tZZNb6MwEIZ/DXfAgbDHhqbbQ6vVKqo26s2NJ2DVYGScAvvrdxycBGqqZlXKAex3xh888wrjkbRofypa5Y+SgfBCn7UeufXCMAijGB9G6XolJqQXMsWZTboIG/4XrOhb9cAZ1KNELaXQvBqLO1mWsNMjjSolm3HaXorxqhXNwBE2Oypc9Q9nOu/VJPIv+j3wLD+tHPg2UtBTshXqnDLZDCSy9kiqpNR9q2hTEAbeiUs/7u6D6HljCkp9zQDL/Y2Kg323TVdrKFBLZVHJmmsuS7tX3Z0AaGhx+lWtlXyFVAqpUC9lieEVFTwrsStgb3L2XIh3GbkuBPYCbL6B0hzB3thBBWfMLLJqcq5hU9GdWbFBG6Gm5KFkYHbum4llqTd2S/a9zWzQfogiOANGZ4IsQKsOU+yAhS1JN+42lwIHsdXyQXFPedR6KjtPfMGODUt+ugoLpwr3VLEGt+6RGwxsueBli43n9AnvgW+yzeyh/3v9+OSUZwreAPr8sMLIpUX8CVpkBlqRQ2sLrkU/YTC0pReSyI/XZrV3lsZIEr6QOLZ+G+h3x+t7aPpX0pzDe7FD8xmqvFNfBAoBi2A5BfRHvCQ0/hZwicstmcAWBDNwWzrcHnh5aL+IDaElbDHtw1XvwxmwBeRTbsGU32YBlzjgflXmkKHi+FGLhTk1XtB/cXY8Pw5K54Bd/1YW2//Fy2idH0+Mmb57VzhuNnLYvfwIHGOD3ymy/gc=&lt;/diagram&gt;&lt;/mxfile&gt;">
+    <defs/>
+    <g>
+        <rect x="0" y="0" width="160" height="40" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 158px; height: 1px; padding-top: 20px; margin-left: 2px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; overflow-wrap: normal;">
+                                System Composition
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2" y="24" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" font-weight="bold">
+                    System Composition
+                </text>
+            </switch>
+        </g>
+        <rect x="0" y="210" width="300" height="30" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 298px; height: 1px; padding-top: 225px; margin-left: 1px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Hardware: Xilinx ZCU 102 / QEMU
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="150" y="229" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Hardware: Xilinx ZCU 102 / QEMU
+                </text>
+            </switch>
+        </g>
+        <rect x="0" y="160" width="300" height="40" fill="#506e3e" stroke="#82b366" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 298px; height: 1px; padding-top: 180px; margin-left: 1px;">
+                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Xen
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="150" y="184" fill="#FFFFFF" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Xen
+                </text>
+            </switch>
+        </g>
+        <rect x="0" y="40" width="80" height="110" fill="#e1d5e7" stroke="#9673a6" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 95px; margin-left: 1px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Zephyr
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="40" y="99" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Zephyr
+                </text>
+            </switch>
+        </g>
+        <rect x="90" y="40" width="100" height="110" fill="#d5e8d4" stroke="#82b366" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 98px; height: 1px; padding-top: 95px; margin-left: 91px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Linux
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="140" y="99" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Linux
+                </text>
+            </switch>
+        </g>
+        <rect x="200" y="40" width="100" height="110" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-dasharray="3 3" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 98px; height: 1px; padding-top: 95px; margin-left: 201px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Optional
+                                <br/>
+                                further DomX
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="250" y="99" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Optional...
+                </text>
+            </switch>
+        </g>
+    </g>
+    <switch>
+        <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
+        <a transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank">
+            <text text-anchor="middle" font-size="10px" x="50%" y="100%">
+                Text is not SVG - cannot display
+            </text>
+        </a>
+    </switch>
+</svg>

--- a/README.md
+++ b/README.md
@@ -1,13 +1,45 @@
-# ELISA systems working group
+# ELISA Systems Working Group
 The Systems WG aims to enable other working groups within ELISA to put their safety claims towards Linux in a wider system context. This is done in the form of a reproducible reference system based on real-world architectures, implemented fully based on Open-Source technologies. The Systems WG encourages interactions with other projects, which either also help enable safety use cases with Open-Source software or plan to make use of mixed-criticality system elements as a base for their product lines.
 
 The working group meets almost every week on Mondays (16:00 UTC, or during DST at 15:00 UTC).
-- The meeting invitiation is send out via mailing list and can be depicted from the ELISA public meeting calendar.
+- The meeting invitation is send out via mailing list and can be depicted from the ELISA public meeting calendar.
 - The minutes of meeting are kept within the repo wiki: https://github.com/elisa-tech/wg-systems/wiki#meetings
+
 
 **We always welcome interested people and (potential) contributors.**
 
-# Resources and links
+## Resources and links
 Link to the mailing list: https://lists.elisa.tech/g/systems 
 Link to ELISA public meeting calendar: https://elisa.tech/community/meetings/
+
+---
+
+# ELISA Example System Documentation
+
+As part of the systems WG activities an example system was created. It represents an
+architecture found in Automotive, Aerospace or Industrial application. It consists of
+an RTOS, Hypervisor, and Linux (yocto and/or Debian).
+
+The system elements used so far are mainly:
+
+- [Apertis](https://www.apertis.org)
+- [Xen](https://xenproject.org/)
+- [Yocto](https://www.yoctoproject.org) (Petalinux)
+- [Zephyr](https://zephyrproject.org/)
+
+They are stacked together as per following block diagram:
+
+![System Overview](Documentation/xen-demo-zcu102/images/system-overview.drawio.svg)
+
+The full documentation can be found under:
+
+  - [Documentation/xen-demo-zcu102/Readme](Documentation/xen-demo-zcu102/Readme.md)
+
+A detailed introduction on the system composition including some demos was recorded
+during the embedded Linux conference 2023
+
+[![IMAGE ALT TEXT HERE](https://img.youtube.com/vi/93bFxGC7G5M/0.jpg)](https://www.youtube.com/watch?v=93bFxGC7G5M&t=519s)
+
+---
+
 


### PR DESCRIPTION
It was hard for some people to understand the documentation and how the system composition should look like.

This PR...
- creates a link on the readme page to find the entry to the documentation
- links to the original talk where the system was explained
- adds an image on the system component and the overall system elements as an overview